### PR TITLE
Remove built-in module crypto from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "license": "ISC",
   "dependencies": {
     "base-64": "^0.1.0",
-    "crypto": "^1.0.1",
     "node-fetch": "^2.2.0",
     "query-string": "^6.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,11 +7,6 @@ base-64@^0.1.0:
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
 
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"


### PR DESCRIPTION
Hi! Cool source plugin!

When I installed this as a local plugin, I got the following warning:

```
warning crypto@1.0.1: This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.
```

This PR removes that warning, and GraphQL still plays nicely.

Thanks!